### PR TITLE
upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usbd-ethernet"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "Communication Device Class Network Control Model (CDC-NCM) class for usb-device"
 license = "MIT"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -21,6 +21,7 @@ pub(crate) trait BufMut {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) trait Buf {
     fn remaining(&self) -> usize;
     fn has_remaining(&self) -> bool {


### PR DESCRIPTION
usb-device introduced incompatible updates in its 0.3 version which are referenced by nrf-usbd. To make this crate work with nrf-usbd (and probably other HALs) a new version needs to be made available.

While we're on it, we also upgrade all other dependencies.